### PR TITLE
feat: use post instead of get to support secure tokens

### DIFF
--- a/source/php/Util/Matomo.php
+++ b/source/php/Util/Matomo.php
@@ -210,17 +210,20 @@ class Matomo {
 
   private function request($filter) {
     $query = array_merge($this->parameters, $filter);
-
-    $queryString = urldecode(http_build_query($query));
-
-    $url = $this->matomoUrl . '?' . $queryString;
+    
+    $url = $this->matomoUrl;
 
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($query));
+
     $result = curl_exec($ch);
+
+    curl_close($ch);
 
     return json_decode($result, true);
   }


### PR DESCRIPTION
Märkte att Staffanstorp fick 403 iom att en api-token var skapad som 'secure' och därmed kräver POST-requests för att få ut data. Bytte ut den för nu men tänkte att det kanske vore bra att byta till POST här för att stödja båda varianter av tokens? 

Har dålig koll på det här repot så vet inte om det ställer till det på nåt annat sätt, bara en idé.